### PR TITLE
Various fixes to soa_migration (detailed below)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+##SOA Migration
+This project hosts a number of lab examples, rules, and microsites for the 2013 Red Hat Conference "Migrating Applications from Red Hat JBoss SOA Platform 5 to 6" hands on lab.   The contents of this project are designed to be used in conjunction with the windup tool.
+
+####Contents :
+
+**advice**:  A number of microsites which document how to migrate specific jboss-esb.xml configuration elements to SwitchYard.
+
+**labs**: A number of examples which show a SOA 5 project and the corresponding completed SOA 6 migration of that project.
+
+**rules** : Windup rules for SOA Migration.     The soa5.windup.xml contains a number of rules not contained int he default windup rules, it is suggested that once you have built and installed windup, you replace rules/base/windup/xml/xml-jboss-esb-config.windup.xml with the contents of soa5.windup.xml. 
+
+**xsl** : XSL documents designed to produce direct mappings from JBoss ESB configuration (jboss-esb.xml) to SwitchYard (switchyard.xml).   

--- a/labs/lab2/windup.sh
+++ b/labs/lab2/windup.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Debug options
+#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y"
+
+CURRENT_DIR=`pwd`
+
+# Setup WINDUP_HOME
+if [ "x$WINDUP_HOME" = "x" ]; then
+    WINDUP_HOME=/home/lab11/Libraries/windup-cli-0.7.0
+fi
+export WINDUP_HOME
+cd $WINDUP_HOME
+
+java $JAVA_OPTS -jar $WINDUP_HOME/windup-cli.jar -input $CURRENT_DIR/soa5_gateways_routers -output $CURRENT_DIR/lab2-report -javaPkgs org.jboss.soa.esb.samples.quickstart.helloworld -source true -fetchRemote true
+

--- a/rules/soa5.windup.xml
+++ b/rules/soa5.windup.xml
@@ -353,22 +353,6 @@
                 </windup:regex-hint>
             </windup:hints>
         </windup:xpath-value>
-
-        <windup:xpath-value description="Action : convert BpmProcessor"
-            xpath="//*[local-name()='action' and @class='org.jboss.soa.esb.services.jbpm.actions.BpmProcessor']/@class"
-            effort="1" inline="true">
-            <windup:hints>
-                <windup:regex-hint regex=".*">
-                    In order to replace the use of the JMSRouter in SwitchYard, you should use a JMS binding.
-                    You may need to review the options for JMS bindings in SwitchYard if you are using the
-                    unwrap property.
-                    
-                    For additional information and tips, see the &lt;a
-                    href="https://github.com/windup/soa-migration/"
-                    target="_blank"&gt;action class microsite&lt;/a&gt;.
-                </windup:regex-hint>
-            </windup:hints>
-        </windup:xpath-value>
         
         <windup:xpath-value description="Action : remove TestMessageStore"
             xpath="//*[local-name()='action' and @class='org.jboss.soa.esb.actions.TestMessageStore']/@class"
@@ -403,22 +387,25 @@
             </windup:hints>
         </windup:xpath-value>
         
-        <!---------------------------->
-        <!-- Needs to be written    -->
-        <!---------------------------->
         <windup:xpath-value description="Action : Replace BpmProcessor"
             xpath="//*[local-name()='action' and @class='org.jboss.soa.esb.services.jbpm.actions.BpmProcessor']/@class"
             effort="1" inline="true">
             <windup:hints>
                 <windup:regex-hint regex=".*">
-                    
+                    The BpmProcessor makes calls to jBPM 3 through the jBPM command API.
+                    SwitchYard supports jBPM 5, so you will need to migrate your existing
+                    workflow from jBPM 3 to jBPM 5 and use a SwitchYard BPM implementation. 
+
+                    For additional information and tips, see the &lt;a
+                    href="https://github.com/windup/soa-migration/"
+                    target="_blank"&gt;BPM microsite&lt;/a&gt;.
                 </windup:regex-hint>
             </windup:hints>
         </windup:xpath-value>
         
-        <!---------------------------->
+        <!-- ###################### -->
         <!-- Not listed in the labs -->
-        <!---------------------------->
+        <!-- ###################### -->
         <windup:xpath-value
             description="Action : service binding configuration in fs-bus"
             xpath="//*[local-name()='fs-bus']/@busid"


### PR DESCRIPTION
Add the missing lab2 windup script (I missed it in the scripts and zips commit), fixes to the SOA5 windup rules (removal of a duplicate rule, added text for jbpm, removed comments causing an error), and a placeholder README for the soa-migration project.
