### PR TITLE
Update action-class-migration.md

### DIFF
--- a/advice/action-class-migration.md
+++ b/advice/action-class-migration.md
@@ -9,7 +9,7 @@ Generally speaking, you should use a CDI Bean Service if the logic in an action 
 ####SOA 5 Action Class
 Here's an example of a SOA 5 Action class:
 ```java
-public class MyAction extends AbstractActionLifecycle
+public class MyJMSListenerAction extends AbstractActionLifecycle
 {   
     protected ConfigTree  _config;
     


### PR DESCRIPTION
class name did not match constructor name

public class MyAction extends AbstractActionLifecycle
             ^^^^^^^^

public MyJMSListenerAction(ConfigTree config) { _config = config; }
       ^^^^^^^^^^^^^^^^^^^
